### PR TITLE
prevent loading directories missing "game.json", such as ".git"

### DIFF
--- a/lib/sandboxer.js
+++ b/lib/sandboxer.js
@@ -17,7 +17,7 @@ module.exports.list = function list() {
   if (Object.keys(games).length === 0) {
     fs.readdirSync(gamesDir).filter(function(file) {
       // Filter directories
-      return fs.statSync(path.join(gamesDir, file)).isDirectory();
+      return fs.statSync(path.join(gamesDir, file)).isDirectory() && fs.existsSync(path.join(gamesDir, file, "game.json"));
     }).forEach(function(gDir) {
       games[gDir] = new Game( path.join(gamesDir, gDir) );
     });

--- a/lib/sandboxer.js
+++ b/lib/sandboxer.js
@@ -17,7 +17,8 @@ module.exports.list = function list() {
   if (Object.keys(games).length === 0) {
     fs.readdirSync(gamesDir).filter(function(file) {
       // Filter directories
-      return fs.statSync(path.join(gamesDir, file)).isDirectory() && fs.existsSync(path.join(gamesDir, file, "game.json"));
+      return fs.statSync(path.join(gamesDir, file)).isDirectory() &&
+      fs.existsSync(path.join(gamesDir, file, 'game.json'));
     }).forEach(function(gDir) {
       games[gDir] = new Game( path.join(gamesDir, gDir) );
     });


### PR DESCRIPTION
I modified this as such so that the server would stop trying to load my .git and node_modules folders as games. You could check for any other required file, but game.json was/is required in the root game folder, and it is hard coded in js-game-server, so it's easy to check for.
